### PR TITLE
Added Spanish translation (fixes #4)

### DIFF
--- a/bookmark-recovery/index.es.html
+++ b/bookmark-recovery/index.es.html
@@ -25,25 +25,24 @@ SOFTWARE.
 Special thanks to David King, Hennie Rozengarden, Jeroen Van Antwerpen,
 Cor Koomen and other TC/RS Chromies in refining this tool.
 -->
-<html lang="en">
+<html lang="es">
 <head>
-<title>Chrome Bookmarks Recovery Tool</title>
+<title>Herramienta de recuperación de marcadores de Chrome</title>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,minimum-scale=1.0">
-<meta name="description" content="Tool to recover your lost Chrome bookmarks">
-<link rel="canonical" href="https://rongjiecomputer.github.io/chrome/bookmark-recovery/">
+<meta name="description" content="Herramienta para recuperar tus marcadores de Chrome perdidos">
 <link rel="alternate" hreflang="en" href="https://rongjiecomputer.github.io/chrome/bookmark-recovery/">
 <link rel="alternate" hreflang="es" href="https://rongjiecomputer.github.io/chrome/bookmark-recovery/index.es.html">
 <meta property="og:type" content="website">
-<meta property="og:title" content="Chrome Bookmarks Recovery Tool">
-<meta property="og:url" content="https://rongjiecomputer.github.io/chrome/bookmark-recovery/">
+<meta property="og:title" content="Herramienta de recuperación de marcadores de Chrome">
+<meta property="og:url" content="https://rongjiecomputer.github.io/chrome/bookmark-recovery/index.es.html">
 <meta property="og:site_name" content="rongjiecomputer.github.io">
-<meta property="og:description" content="Tool to recover your lost Chrome bookmarks">
+<meta property="og:description" content="Herramienta para recuperar tus marcadores de Chrome perdidos">
 <meta property="og:image" content="https://rongjiecomputer.github.io/chrome/bookmark-recovery/share.png">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Chrome Bookmarks Recovery Tool">
-<meta name="twitter:url" content="https://rongjiecomputer.github.io/chrome/bookmark-recovery/">
-<meta name="twitter:description" content="Tool to recover your lost Chrome bookmarks">
+<meta name="twitter:title" content="Herramienta de recuperación de marcadores de Chrome">
+<meta name="twitter:url" content="https://rongjiecomputer.github.io/chrome/bookmark-recovery/index.es.html">
+<meta name="twitter:description" content="Herramienta para recuperar tus marcadores de Chrome perdidos">
 <meta name="twitter:image" content="https://rongjiecomputer.github.io/chrome/bookmark-recovery/share.png">
 <style>
 html, body {
@@ -212,7 +211,7 @@ output a[data-disabled] {
 	right: 18px;
 	top: 50%;
 	width: 22px;
-	height: 22px;
+	height: 22px;Tool to recover your lost Chrome bookmarks
 	transition: transform 0.3s;
 }
 .zip-content {
@@ -250,7 +249,7 @@ footer a {
 <body>
 
 <header>
-	<h1>Chrome Bookmarks Recovery Tool</h1>
+	<h1>Herramienta de recuperación de marcadores de Chrome</h1>
 </header>
 
 <main>
@@ -258,70 +257,69 @@ footer a {
 		<a href="#windows" id="windows-tab" role="tab" aria-controls="windows-soln">Windows</a>
 		<a href="#mac" id="mac-tab" role="tab" aria-controls="mac-soln">Mac</a>
 		<a href="#linux" id="linux-tab" role="tab" aria-controls="linux-soln">Linux</a>
-		<a href="#google" id="google-tab" role="tab" aria-controls="google-soln">Google Server</a>
+		<a href="#google" id="google-tab" role="tab" aria-controls="google-soln">Servidor de Google</a>
 	</div>
 	<div class="soln" id="windows-soln" role="tabpanel" aria-labelledby="windows-tab" aria-hidden="true" tabindex="0">
-		<p>Here is how to recover your lost bookmarks (Windows):</p>
+		<p>Sigue estos pasos para recuperar tus marcadores perdidos (Windows):</p>
 		<ol>
-			<li>Copy <code>C:\Users\%username%\AppData\Local\Google\Chrome\User Data</code> into File Explorer.</li>
-			<li>In search bar, type <code>Bookmarks</code>, you will see a list of files named <code>Bookmarks</code> and/or <code>Bookmarks.bak</code>. (<i>Note: If there is more than one user using the same Chrome, bookmarks from other users will be listed too</i>)</li>
-			<li>Select all the files with mouse and drag them to the block below.</li>
-			<li>Download all the HTML files.</li>
-			<li>Open each HTML file with Chrome and determine the HTML file that contains your bookmarks. (<i>Note: The largest file is most likely the correct one</i>)</li>
-			<li>In your Chrome browser, click the Chrome menu icon and go to Bookmarks &gt; Bookmark Manager.</li>
-			<li>Click the menu icon beside search bar and click "Import Bookmarks".</li>
-			<li>Select the HTML file that contains your bookmarks.</li>
-			<li>Your bookmarks should now be imported back to Chrome.</li>
+			<li>Abre el explorador de Windows y navega al directorio <code>C:\Users\%username%\AppData\Local\Google\Chrome\User Data</code> (copia y pega esa dirección en la barra superior).</li>
+			<li>En la barra de búsqueda, escribe <code>Bookmarks</code>, verás una lista de ficheros llamados <code>Bookmarks</code> y/o <code>Bookmarks.bak</code>. (<i>Nota: Si tienes más de un usuario en Chrome, los marcadores de los otros usuarios también saldrán en la lista</i>)</li>
+			<li>Selecciona todos los archivos con tu ratón y arrástralos al bloque de aquí abajo.</li>
+			<li>Descarga todos los ficheros HTML que generará esta página web automáticamente.</li>
+			<li>Abre cada archivo HTML con Chrome y determina cuál es el archivo que contiene tus marcadores. (<i>Nota: lo más probable es que el fichero más grande sea el correcto, de todas formas siempre puedes intentar importarlos uno a uno hasta dar con el correcto</i>)</li>
+			<li>En Chrome, abre el menú de Chrome y ve a Marcadores &gt; Administrador de marcadores.</li>
+			<li>Haz clic en el menú que hay al lado de la barra de búsqueda y haz clic en "Importar marcadores".</li>
+			<li>Selecciona el archivo HTML que contiene tus marcadores.</li>
+			<li>Tus marcadores se deberían haber importado ahora a Chrome en una carpeta nueva en la barra de marcadores.</li>
 		</ol>
 	</div>
 	<div class="soln" id="mac-soln" role="tabpanel" aria-labelledby="mac-tab" aria-hidden="true" tabindex="0">
-		<p>Here is how to recover your lost bookmarks (Mac):</p>
+		<p>Sigue estos pasos para recuperar tus marcadores perdidos (Mac):</p>
 		<ol>
-			<li>In the Mac menu bar at the top of the screen, click Go.</li>
-			<li>Select Go to Folder.</li>
-			<li>Type <code>~/Library/Application Support/Google/Chrome</code> and click Go.</li>
-			<li>In search bar, type <code>Bookmarks</code>, you will see a list of files named <code>Bookmarks</code> and/or <code>Bookmarks.bak</code>. (<i>Note: If there is more than one user using the same Chrome, bookmarks from other users will be listed too</i>)</li>
-			<li>Select all the files with mouse and drag them to the block below.</li>
-			<li>Download all the HTML files.</li>
-			<li>Open each HTML file with Chrome and determine the HTML file that contains your bookmarks. (<i>Note: The largest file is most likely the correct one</i>)</li>
-			<li>In your Chrome browser, click the Chrome menu icon and go to Bookmarks &gt; Bookmark Manager.</li>
-			<li>Click the menu icon beside search bar and click "Import Bookmarks".</li>
-			<li>Select the HTML file that contains your bookmarks.</li>
-			<li>Your bookmarks should now be imported back to Chrome.</li>
+			<li>En el menú del Mac de arriba del todo de la pantalla, haz clic en Ir.</li>
+			<li>Selecciona Ir a la carpeta.</li>
+			<li>Escribe <code>~/Library/Application Support/Google/Chrome</code> y haz clic en Ir.</li>
+			<li>En la barra de búsqueda escribe <code>Bookmarks</code> (asegúrate de seleccionar que busque en la carpeta Chrome), verás una lista de archivos llamados <code>Bookmarks</code> y/o <code>Bookmarks.bak</code>. (<i>Nota: Si tienes más de un usuario en Chrome, los marcadores de los otros usuarios también saldrán en la lista</i>)</li>
+			<li>Selecciona todos los archivos con tu ratón y arrástralos al bloque de aquí abajo.</li>
+			<li>Descarga todos los ficheros HTML que generará esta página web automáticamente.</li>
+			<li>Abre cada archivo HTML con Chrome y determina cuál es el archivo que contiene tus marcadores. (<i>Nota: lo más probable es que el fichero más grande sea el correcto, de todas formas siempre puedes intentar importarlos uno a uno hasta dar con el correcto</i>)</li>
+			<li>En Chrome, abre el menú de Chrome y ve a Marcadores &gt; Administrador de marcadores.</li>
+			<li>Haz clic en el menú que hay al lado de la barra de búsqueda y haz clic en "Importar marcadores".</li>
+			<li>Selecciona el archivo HTML que contiene tus marcadores.</li>
+			<li>Tus marcadores se deberían haber importado ahora a Chrome en una carpeta nueva en la barra de marcadores.</li>
 		</ol>
 	</div>
 	<div class="soln" id="linux-soln" role="tabpanel" aria-labelledby="linux-tab" aria-hidden="true" tabindex="0">
-		<p>Here is how to recover your lost bookmarks (Linux):</p>
+		<p>Sigue estos pasos para recuperar tus marcadores perdidos (Linux):</p>
 		<ol>
-			<li>Open your file explorer (<i>Nautilus, Dolphin ...</i>).</li>
-			<li>Go to <code>~/.config/google-chrome</code> (<i>Use Ctrl+L on Nautilus</i>).</li>
-			<li>Search for <code>Bookmarks*</code>, you will see a list of files named <code>Bookmarks</code> and/or <code>Bookmarks.bak</code>. (<i>Note: If there is more than one user using the same Chrome, bookmarks from other users will be listed too</i>)</li>
-			<li>Select all the files with mouse and drag them to the block below.</li>
-			<li>Download all the HTML files.</li>
-			<li>Open each HTML file with Chrome and determine the HTML file that contains your bookmarks. (<i>Note: The largest file is most likely the correct one</i>)</li>
-			<li>In your Chrome browser, click the Chrome menu icon and go to Bookmarks &gt; Bookmark Manager.</li>
-			<li>Click the menu icon beside search bar and click "Import Bookmarks".</li>
-			<li>Select the HTML file that contains your bookmarks.</li>
-			<li>Your bookmarks should now be imported back to Chrome.</li>
+			<li>Abre tu explorador de archivos (<i>Nautilus, Dolphin ...</i>).</li>
+			<li>Ve a <code>~/.config/google-chrome</code> (<i>usa Ctrl+L en Nautilus</i>).</li>
+			<li>Busca <code>Bookmarks*</code>; verás una lista de archivos llamados <code>Bookmarks</code> y/o <code>Bookmarks.bak</code>. (<i>Nota: Si tienes más de un usuario en Chrome, los marcadores de los otros usuarios también saldrán en la lista</i>)</li>
+			<li>Selecciona todos los archivos con tu ratón y arrástralos al bloque de aquí abajo.</li>
+			<li>Descarga todos los ficheros HTML que generará esta página web automáticamente.</li>
+			<li>Abre cada archivo HTML con Chrome y determina cuál es el archivo que contiene tus marcadores. (<i>Nota: lo más probable es que el fichero más grande sea el correcto, de todas formas siempre puedes intentar importarlos uno a uno hasta dar con el correcto</i>)</li>
+			<li>En Chrome, abre el menú de Chrome y ve a Marcadores &gt; Administrador de marcadores.</li>
+			<li>Haz clic en el menú que hay al lado de la barra de búsqueda y haz clic en "Importar marcadores".</li>
+			<li>Selecciona el archivo HTML que contiene tus marcadores.</li>
+			<li>Tus marcadores se deberían haber importado ahora a Chrome en una carpeta nueva en la barra de marcadores.</li>
 		</ol>
 	</div>
 	<div class="soln" id="google-soln" role="tabpanel" aria-labelledby="google-tab" aria-hidden="true" tabindex="0">
-		<p>If you are sure that Chrome sync data stored in Google server still have your bookmarks, here is how to retrieve them from Google server:</p>
+		<p>Si estás seguro que en los datos de la sincronización de Chrome que hay en los servidores de Google todavía están tus marcadores, puedes seguir los siguientes pasos para recuperarlos del servidor de Google:</p>
 		<ol>
-			<li>Go to <a href="https://takeout.google.com/settings/takeout" target="_blank">Google Takeout</a> and sign in to the Google Account used for Chrome Sync.</li>
-			<li>Click the "Select None" button.</li>
-			<li>Check "Chrome" in product list.</li>
-			<li>Expand "All Chrome data types".</li>
-			<li>Click the "Select Chrome data" option.</li>
-			<li>In the popup, check the "Bookmarks" option and uncheck the rest.</li>
-			<li>Scroll down to the bottom of the page and click "Next" button.</li>
-			<li>Click the "Create archive" button.</li>
-			<li>Download and unzip the archive.</li>
-			<li>In the unzipped folder, navigate to "Chrome" folder. The HTML file named "Bookmarks" is the one we need.</li>
-			<li>In your Chrome browser, click the Chrome menu icon and go to Bookmarks &gt; Bookmark Manager.</li>
-			<li>Click the menu icon beside search bar and click "Import Bookmarks".</li>
-			<li>Select the HTML file that contains your bookmarks.</li>
-			<li>Your bookmarks should now be imported back to Chrome.</li>
+			<li>Ve a <a href="https://takeout.google.com/settings/takeout" target="_blank">Google Takeout</a> e inicia sesión con la cuenta de Google que usas para la sincronización de Chrome.</li>
+			<li>Haz clic en el botón "Desmarcar todo".</li>
+			<li>Activa el producto "Chrome" en el listado.</li>
+			<li>Haz clic en el botón "Se han incluido todos los datos de Chrome".</li>
+			<li>En la ventana emergente, activa solo la opción "Bookmarks" y desactiva el resto.</li>
+			<li>Haz clic en "Aceptar" y ve hasta el final de la página para hacer clic en el botón "Siguiente paso".</li>
+			<li>Haz clic en el botón "Programar otra exportación".</li>
+			<li>Descarga y descomprime el archivo ZIP que se exportará.</li>
+			<li>En la carpeta descomprimida, navega a la carpeta "Chrome". El archivo HTML llamado "Bookmarks" es el que necesitamos.</li>
+			<li>En Chrome, abre el menú de Chrome y ve a Marcadores &gt; Administrador de marcadores.</li>
+			<li>Haz clic en el menú que hay al lado de la barra de búsqueda y haz clic en "Importar marcadores".</li>
+			<li>Selecciona el archivo HTML que contiene tus marcadores.</li>
+			<li>Tus marcadores se deberían haber importado ahora a Chrome en una carpeta nueva en la barra de marcadores.</li>
 		</ol>
 	</div>
 	<form id="block" tabindex="-1">
@@ -331,40 +329,40 @@ footer a {
 			</svg>
 			<label>
 				<input tabindex="0" type="file" multiple id="input" aria-describedby="tooltip"/>
-				<b>Choose a file</b> or drag it here
+				<b>Selecciona un archivo</b> o arrástralo aquí
 			</label>
-			<div role="tooltip" id="tooltip">Search with the keyword of "Bookmarks" and select all the files found.</div>
+			<div role="tooltip" id="tooltip">Busca "Bookmarks" en la carpeta de datos de Chrome y selecciona todos los archivos que encuentres.</div>
 		</div>
-		<output id="output" role="alert" aria-live="assertive" aria-hidden="true">The HTML file will be produced here later.</output>
+		<output id="output" role="alert" aria-live="assertive" aria-hidden="true">El fichero HTML se producirá aquí más tarde.</output>
 	</form>
-	<h3>Other ways to recover bookmarks</h3>
+	<h3>Otras maneras de recuperar marcadores</h3>
 	<div class="zip">
-		<button id="zip-h-2" class="zip-h" aria-expanded="false" aria-controls="zip-2">Personal backup</button>
+		<button id="zip-h-2" class="zip-h" aria-expanded="false" aria-controls="zip-2">Copia de seguridad personal</button>
 		<div id="zip-2" role="region" aria-labelledby="zip-h-2" aria-hidden="true" class="zip-content">
-			<p>In the case when backups of your computer are available, find the bookmarks files in the backups, upload them to this tool and continue with the steps above.</p>
+			<p>En el caso de que dispongas de copias de seguridad de tu ordenador, encuentra los archivos de los marcadores que haya en las copias de seguridad, súbelas a este herramienta y continúa con los pasos de arriba.</p>
 		</div>
 	</div>
 	<div class="zip">
-		<button id="zip-h-3" class="zip-h" aria-expanded="false" aria-controls="zip-3">Recover from old devices</button>
+		<button id="zip-h-3" class="zip-h" aria-expanded="false" aria-controls="zip-3">Recuperarlos desde un dispositivo viejo</button>
 		<div id="zip-3" role="region" aria-labelledby="zip-h-3" aria-hidden="true" class="zip-content">
-			<p>Do you have a device (e.g: old laptop) that is signed in to your Google Account and it hasn't been synced since the moment your bookmarks were lost? If so, find the files in this device, upload them to this tool and continue with the steps above.</p>
+			<p>¿Tienes un dispositivo (por ejemplo un portátil antiguo) donde has iniciado sesión en Chrome con tu cuenta de Google y todavía no se ha sincronizado desde el momento en que perdiste tus marcadores? Si es así, encuentra los archivos de los marcadores en ese dispositivo, súbelos a esta herramienta y sigue con los pasos de arriba.</p>
 		</div>
 	</div>
 	<div class="zip">
-		<button id="zip-h-4" class="zip-h" aria-expanded="false" aria-controls="zip-4">Tips and tricks</button>
+		<button id="zip-h-4" class="zip-h" aria-expanded="false" aria-controls="zip-4">Consejos y trucos</button>
 		<div id="zip-4" role="region" aria-labelledby="zip-h-4" aria-hidden="true" class="zip-content">
-			<p>You can use this tool or <i>Export Bookmarks</i> function in Bookmark Manager to generate HTML file that can be used as archive/backup of your bookmarks. Regularly making backup is useful in case your bookmarks get lost again in the future.</p>
+			<p>Puedes usar esta herramienta o la función <i>Exportar marcadores</i> del administrador de marcadores para generar archivos HTML que se pueden usar como copias de seguridad de tus marcadores. Hacer copias de seguridad regulares puede llegar a ser útil en el caso que vuelvas a perder tus marcadores en el futuro.</p>
 		</div>
 	</div>
-	<p><i>Disclaimer: this is not an official Google product.</i></p>
+	<p><i>Aviso: esta herramienta no es un producto oficial de Google.</i></p>
 </main>
 
 <footer>
-	<a href="https://support.google.com/chrome/">Chrome Help Center</a>
-	<a href="https://productforums.google.com/forum/#!forum/chrome">Chrome Help Forum</a>
+	<a href="https://support.google.com/chrome/">Centro de ayuda de Chrome</a>
+	<a href="https://support.google.com/chrome/community/?hl=es">Foro de ayuda de Chrome</a>
 </footer>
 
-<a class="github-link" href="https://github.com/rongjiecomputer/chrome/tree/gh-pages/bookmark-recovery" title="Source on Github">
+<a class="github-link" href="https://github.com/rongjiecomputer/chrome/tree/gh-pages/bookmark-recovery" title="Código fuente en Github">
 	<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 60.5 60.5" width="60" height="60">
 		<polygon fill="#9dacb3" points="60.5,60.5 0,0 60.5,0"/>
 		<path fill="#f5f5f5" d="M43.1,5.8c-6.6,0-12,5.4-12,12c0,5.3,3.4,9.8,8.2,11.4c0.6,0.1,0.8-0.3,0.8-0.6c0-0.3,0-1,0-2c-3.3,0.7-4-1.6-4-1.6c-0.5-1.4-1.3-1.8-1.3-1.8c-1.1-0.7,0.1-0.7,0.1-0.7c1.2,0.1,1.8,1.2,1.8,1.2c1.1,1.8,2.8,1.3,3.5,1c0.1-0.8,0.4-1.3,0.8-1.6c-2.7-0.3-5.5-1.3-5.5-5.9c0-1.3,0.5-2.4,1.2-3.2c-0.1-0.3-0.5-1.5,0.1-3.2c0,0,1-0.3,3.3,1.2c1-0.3,2-0.4,3-0.4c1,0,2,0.1,3,0.4c2.3-1.6,3.3-1.2,3.3-1.2c0.7,1.7,0.2,2.9,0.1,3.2c0.8,0.8,1.2,1.9,1.2,3.2c0,4.6-2.8,5.6-5.5,5.9c0.4,0.4,0.8,1.1,0.8,2.2c0,1.6,0,2.9,0,3.3c0,0.3,0.2,0.7,0.8,0.6c4.8-1.6,8.2-6.1,8.2-11.4C55.1,11.2,49.7,5.8,43.1,5.8z"/>
@@ -416,12 +414,12 @@ Bookmark.prototype.newLink = function() {
 	var a = document.createElement('a');
 	a.download = 'bookmark_backup.html';
 	a.href = window.URL.createObjectURL(blob);
-	a.textContent = 'Download ready (' + this.count + ' bookmarks found)';
+	a.textContent = 'Descarga lista (' + this.count + ' marcadores encontrados)';
 	a.onclick = function(e) {
 		if ('disabled' in this.dataset) {
 			return false;
 		}
-		this.textContent = 'Downloaded';
+		this.textContent = 'Descargado';
 		this.dataset.disabled = true;
 		setTimeout(function() {
 			window.URL.revokeObjectURL(this.href);
@@ -432,14 +430,14 @@ Bookmark.prototype.newLink = function() {
 function readFile(file) {
 	var reader = new FileReader();
 	var li = document.createElement('li');
-	li.innerHTML = '<strong>Last updated: ' + (file.lastModifiedDate !== undefined ? file.lastModifiedDate.toLocaleDateString() : 'n/a') + '</strong> (' + file.size + 'B) ';
+	li.innerHTML = '<strong>Modificado por última vez: ' + (file.lastModifiedDate !== undefined ? file.lastModifiedDate.toLocaleDateString() : 'n/a') + '</strong> (' + file.size + 'B) ';
 	reader.onloadend = function() {
 		try {
 			var bookmark = new Bookmark(reader.result);
 			bookmark.parse();
 			li.appendChild(bookmark.newLink());
 		} catch(e) {
-			li.innerHTML += '<b>Error! The file is invalid. Try again!</b>';
+			li.innerHTML += '<b>¡Error! El archivo no es válido. ¡Vuélvelo a intentar!</b>';
 		}
 	};
 	reader.readAsText(file);


### PR DESCRIPTION
Here's the translation as we talked in issue #4 :)

Feel free to change the filename or its path to whatever you want to. I used the ugly "index.es.html" because it's a standard I've seen in many websites.

Also, I added some `<link rel="alternate">` tags as suggested here: [Tell Google about localized versions of your page - Search Console Help](https://support.google.com/webmasters/answer/189077)